### PR TITLE
Add FastAPI backend and local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Parth Site
+
+This repository contains a Next.js front‑end and a small FastAPI back‑end that share a local SQLite database.
+
+## Prerequisites
+
+- Node.js 18+ and [pnpm](https://pnpm.io)
+- Python 3.10+
+- SQLite (bundled with Node.js/Python)
+
+## Initial setup
+
+1. Install Node dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Create an `.env` file in the project root with the database location:
+
+   ```dotenv
+   DATABASE_URL="file:./prisma/dev.db"
+   ```
+
+3. Create the SQLite database using Prisma:
+
+   ```bash
+   pnpx prisma migrate dev --name init
+   ```
+
+   The database file will be created at `prisma/dev.db`.
+
+## Running the Next.js website
+
+```bash
+pnpm dev
+```
+
+The site will be available at <http://localhost:3000>.
+
+## Running the FastAPI back‑end
+
+1. (Optional) create and activate a virtual environment:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Install Python dependencies:
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+3. Start the API server:
+
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
+   The API will be available at <http://localhost:8000>. Useful endpoints:
+
+   - `GET /` – health check
+   - `GET /colleges` – list colleges stored in the database
+
+Both services read and write to the same local SQLite database (`prisma/dev.db`), so all code and data remain on your laptop.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI
+import sqlite3
+import os
+from pathlib import Path
+
+app = FastAPI()
+
+# Resolve database path from DATABASE_URL (e.g. 'file:./prisma/dev.db')
+def get_db_path() -> Path:
+    database_url = os.getenv("DATABASE_URL", "file:./prisma/dev.db")
+    db_relative = database_url.replace("file:", "", 1)
+    return (Path(__file__).resolve().parent.parent / db_relative).resolve()
+
+DB_PATH = get_db_path()
+
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@app.get("/")
+async def read_root():
+    return {"status": "ok"}
+
+
+@app.get("/colleges")
+async def list_colleges():
+    conn = get_connection()
+    rows = conn.execute("SELECT id, name, slug, location, logoUrl FROM College").fetchall()
+    conn.close()
+    return [dict(row) for row in rows]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add a minimal FastAPI backend using the existing SQLite database
- document how to run the Next.js frontend and the FastAPI backend locally

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4f035ea1883309df5c4c11d8ff6bb