### PR TITLE
Use JSON tags for SQLite Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model Material {
   description String?
   fileUrl     String?
   externalUrl String?
-  tags        String[]
+  tags        Json?      @default("[]")
   year        Int?
   author      String?
   createdAt   DateTime     @default(now())
@@ -82,7 +82,7 @@ model PYQ {
   examType     String
   fileUrl      String
   solutionsUrl String?
-  tags         String[]
+  tags         Json?     @default("[]")
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 }
@@ -94,7 +94,7 @@ model Video {
   youtubeId   String
   title       String
   description String?
-  tags        String[]
+  tags        Json?     @default("[]")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- replace String[] tags with Json in Material, PYQ, Video models to be compatible with SQLite

## Testing
- `DATABASE_URL=file:./prisma/dev.db pnpx prisma validate`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b50876c0c483308d6e79eba96df873