### PR TITLE
Handle admin request errors and prevent hydration mismatches

### DIFF
--- a/app/admin/colleges/table.tsx
+++ b/app/admin/colleges/table.tsx
@@ -37,7 +37,15 @@ export default function CollegesClient() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify(values),
     })
-    if (!res.ok) throw new Error("Create failed")
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      toast({
+        title: "Create failed",
+        description: data?.error || data?.message || res.statusText,
+        variant: "destructive",
+      })
+      return
+    }
     toast({ title: "Created" })
     mutate()
   }
@@ -48,14 +56,30 @@ export default function CollegesClient() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify(values),
     })
-    if (!res.ok) throw new Error("Update failed")
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      toast({
+        title: "Update failed",
+        description: data?.error || data?.message || res.statusText,
+        variant: "destructive",
+      })
+      return
+    }
     toast({ title: "Updated" })
     mutate()
   }
 
   async function remove(id: string) {
     const res = await fetch(`/api/colleges/${id}`, { method: "DELETE" })
-    if (!res.ok) throw new Error("Delete failed")
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      toast({
+        title: "Delete failed",
+        description: data?.error || data?.message || res.statusText,
+        variant: "destructive",
+      })
+      return
+    }
     toast({ title: "Deleted" })
     mutate()
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning className={inter.variable + " " + sourceSerif.variable + " antialiased"}>
-      <body>
+      <body suppressHydrationWarning>
         {/* Wrap with ThemeProvider to enable next-themes across the app */}
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <ClientLayout>{children}</ClientLayout>

--- a/components/user-state.tsx
+++ b/components/user-state.tsx
@@ -69,7 +69,9 @@ export function UserStateProvider({ children }: { children: React.ReactNode }) {
 
 export function ContinueStudyingShelf() {
   const { bookmarks, recents } = useUserState()
-  const items = bookmarks.length ? bookmarks.slice(0, 6) : recents.slice(0, 6)
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => setHydrated(true), [])
+  const items = hydrated ? (bookmarks.length ? bookmarks.slice(0, 6) : recents.slice(0, 6)) : []
 
   if (!items.length) {
     return (


### PR DESCRIPTION
## Summary
- Show descriptive toasts for college create, update and delete failures
- Suppress hydration mismatch on the body element
- Delay "Continue Studying" shelf rendering until after client hydration

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f2453f08330b60aaf6ea8b0210f