### PR TITLE
Load dynamic data for browse and content pages

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { prisma } from "@/lib/prisma"
+
+export const dynamic = "force-dynamic"
 
 type SearchParams = { by?: "college" | "course" | "subject" }
 
@@ -45,19 +48,16 @@ export default function BrowsePage({ searchParams }: { searchParams: SearchParam
   )
 }
 
-function CollegeGrid() {
-  const demo = [
-    { slug: "mlu", name: "Modern Learning University" },
-    { slug: "nit", name: "National Institute of Tech" },
-  ]
+async function CollegeGrid() {
+  const colleges = await prisma.college.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="colleges" className="space-y-3">
       <h2 id="colleges" className="font-serif text-xl font-semibold">
         Colleges
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((c) => (
-          <Link key={c.slug} href={`/college/${c.slug}`} className="group">
+        {colleges.map((c) => (
+          <Link key={c.id} href={`/college/${c.slug}`} className="group">
             <Card className="transition-colors group-hover:border-foreground/20">
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">{c.name}</CardTitle>
@@ -73,20 +73,16 @@ function CollegeGrid() {
   )
 }
 
-function CourseGrid() {
-  const demo = [
-    { slug: "btech-cs", name: "B.Tech Computer Science" },
-    { slug: "btech-me", name: "B.Tech Mechanical" },
-    { slug: "btech-cs-nit", name: "B.Tech Computer Science (NIT)" },
-  ]
+async function CourseGrid() {
+  const courses = await prisma.course.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="courses" className="space-y-3">
       <h2 id="courses" className="font-serif text-xl font-semibold">
         Courses
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((c) => (
-          <Link key={c.slug} href={`/course/${c.slug}`} className="group">
+        {courses.map((c) => (
+          <Link key={c.id} href={`/course/${c.slug}`} className="group">
             <Card className="transition-colors group-hover:border-foreground/20">
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">{c.name}</CardTitle>
@@ -102,20 +98,16 @@ function CourseGrid() {
   )
 }
 
-function SubjectGrid() {
-  const demo = [
-    { slug: "dsa", name: "Data Structures & Algorithms" },
-    { slug: "dbms", name: "DBMS" },
-    { slug: "thermodynamics", name: "Thermodynamics" },
-  ]
+async function SubjectGrid() {
+  const subjects = await prisma.subject.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="subjects" className="space-y-3">
       <h2 id="subjects" className="font-serif text-xl font-semibold">
         Subjects
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((s) => (
-          <Link key={s.slug} href={`/subject/${s.slug}`} className="group">
+        {subjects.map((s) => (
+          <Link key={s.id} href={`/subject/${s.slug}`} className="group">
             <Card className="transition-colors group-hover:border-foreground/20">
               <CardHeader className="pb-2">
                 <CardTitle className="text-base">{s.name}</CardTitle>

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -1,30 +1,28 @@
 import { FileText, HelpCircle, PlayCircle } from "lucide-react"
 import Link from "next/link" // use internal viewers
+import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
-import { demoSubjects, demoNotes, demoVideos } from "@/lib/demo-data"
+import { prisma } from "@/lib/prisma"
 
-export default function SubjectPage({ params }: { params: { slug: string } }) {
-  const subject = demoSubjects.find((s) => s.slug === params.slug)
-  const title = subject?.name || slugToTitle(params.slug)
-  const notes = demoNotes.filter((n) => n.subjectId === subject?.id)
-  const videos = demoVideos.filter((v) => v.subjectId === subject?.id)
-  const pyqs = [
-    {
-      title: "Previous Year Paper (Sample 1)",
-      url: "https://web.stanford.edu/class/archive/cs/cs106a/cs106a.1212/handouts_midterm/CS106A-Midterm.pdf",
-    },
-    {
-      title: "Previous Year Paper (Sample 2)",
-      url: "https://www.math.toronto.edu/ivan/mat185f10/MAT185F10Midterm.pdf",
-    },
-  ]
+export const dynamic = "force-dynamic"
+
+export default async function SubjectPage({ params }: { params: { slug: string } }) {
+  const subject = await prisma.subject.findFirst({
+    where: { slug: params.slug },
+    include: { materials: true, pyqs: true, videos: true },
+  })
+  if (!subject) return notFound()
+
+  const notes = subject.materials
+  const pyqs = subject.pyqs
+  const videos = subject.videos
 
   return (
     <div className="space-y-6">
-      <PageTracker title={title} href={`/subject/${params.slug}`} type="nav" />
+      <PageTracker title={subject.name} href={`/subject/${subject.slug}`} type="nav" />
       <header className="space-y-1">
-        <h1 className="font-serif text-2xl font-semibold">{title}</h1>
-        <p className="text-sm text-muted-foreground">Notes, PYQs, and videos for {title}.</p>
+        <h1 className="font-serif text-2xl font-semibold">{subject.name}</h1>
+        <p className="text-sm text-muted-foreground">Notes, PYQs, and videos for {subject.name}.</p>
       </header>
 
       <section aria-labelledby="materials" className="space-y-3">
@@ -36,25 +34,25 @@ export default function SubjectPage({ params }: { params: { slug: string } }) {
             ? notes.map((n) => (
                 <Link
                   key={n.id}
-                  href={`/view/note?title=${encodeURIComponent(n.title)}&url=${encodeURIComponent(n.url)}`}
+                  href={`/view/note?title=${encodeURIComponent(n.title)}&url=${encodeURIComponent(
+                    n.fileUrl || n.externalUrl || "",
+                  )}`}
                   className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
                 >
                   <div className="flex items-center gap-2">
                     <FileText className="h-4 w-4" aria-hidden="true" />
                     <span className="text-sm font-medium">{n.title}</span>
                   </div>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    {n.type === "pdf" ? "PDF" : "Web"} • Opens inside site
-                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">{n.type} • Opens inside site</p>
                 </Link>
               ))
             : [1, 2, 3].map((i) => (
                 <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
                   <div className="flex items-center gap-2">
                     <FileText className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">Chapter {i} Notes</span>
+                    <span className="text-sm font-medium">Material {i}</span>
                   </div>
-                  <p className="mt-2 text-sm text-muted-foreground">PDF • Placeholder</p>
+                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
                 </article>
               ))}
         </div>
@@ -65,21 +63,31 @@ export default function SubjectPage({ params }: { params: { slug: string } }) {
           PYQs
         </h2>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {pyqs.map((q) => (
-            <a
-              key={q.title}
-              href={q.url}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
-            >
-              <div className="flex items-center gap-2">
-                <HelpCircle className="h-4 w-4" aria-hidden="true" />
-                <span className="text-sm font-medium">{q.title}</span>
-              </div>
-              <p className="mt-2 text-sm text-muted-foreground">PDF • Opens in new tab</p>
-            </a>
-          ))}
+          {pyqs.length > 0
+            ? pyqs.map((q) => (
+                <a
+                  key={q.id}
+                  href={q.fileUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
+                >
+                  <div className="flex items-center gap-2">
+                    <HelpCircle className="h-4 w-4" aria-hidden="true" />
+                    <span className="text-sm font-medium">{q.examType} {q.year}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">PDF • Opens in new tab</p>
+                </a>
+              ))
+            : [1, 2, 3].map((i) => (
+                <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
+                  <div className="flex items-center gap-2">
+                    <HelpCircle className="h-4 w-4" aria-hidden="true" />
+                    <span className="text-sm font-medium">PYQ {i}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
+                </article>
+              ))}
         </div>
       </section>
 
@@ -92,7 +100,9 @@ export default function SubjectPage({ params }: { params: { slug: string } }) {
             ? videos.map((v) => (
                 <Link
                   key={v.id}
-                  href={`/view/video?v=${encodeURIComponent(v.url)}&title=${encodeURIComponent(v.title)}`}
+                  href={`/view/video?v=${encodeURIComponent(
+                    `https://www.youtube.com/watch?v=${v.youtubeId}`,
+                  )}&title=${encodeURIComponent(v.title)}`}
                   className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
                 >
                   <div className="flex items-center gap-2">
@@ -106,17 +116,13 @@ export default function SubjectPage({ params }: { params: { slug: string } }) {
                 <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
                   <div className="flex items-center gap-2">
                     <PlayCircle className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">Lecture {i}</span>
+                    <span className="text-sm font-medium">Video {i}</span>
                   </div>
-                  <p className="mt-2 text-sm text-muted-foreground">YouTube • Placeholder</p>
+                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
                 </article>
               ))}
         </div>
       </section>
     </div>
   )
-}
-
-function slugToTitle(s: string) {
-  return s.replace(/-/g, " ").replace(/\b\w/g, (m) => m.toUpperCase())
 }


### PR DESCRIPTION
## Summary
- Fetch colleges, courses, and subjects from the database for browse view
- Pull college, course, and subject details dynamically so admin edits show on the site

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run build` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_68b5120e35e08330b3a34244d9e7f120