### PR TITLE
Fix browse tabs to fetch live data from Prisma

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { prisma } from "@/lib/prisma"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 type SearchParams = { by?: "college" | "course" | "subject" }
 
@@ -45,87 +50,88 @@ export default function BrowsePage({ searchParams }: { searchParams: SearchParam
   )
 }
 
-function CollegeGrid() {
-  const demo = [
-    { slug: "mlu", name: "Modern Learning University" },
-    { slug: "nit", name: "National Institute of Tech" },
-  ]
+async function CollegeGrid() {
+  const colleges = await prisma.college.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="colleges" className="space-y-3">
       <h2 id="colleges" className="font-serif text-xl font-semibold">
         Colleges
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((c) => (
-          <Link key={c.slug} href={`/college/${c.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{c.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Explore courses and subjects</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+        {colleges.length ? (
+          colleges.map((c) => (
+            <Link key={c.id} href={`/college/${c.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{c.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Explore courses and subjects</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))
+        ) : (
+          <p className="col-span-full text-sm text-muted-foreground">No colleges found.</p>
+        )}
       </div>
     </section>
   )
 }
 
-function CourseGrid() {
-  const demo = [
-    { slug: "btech-cs", name: "B.Tech Computer Science" },
-    { slug: "btech-me", name: "B.Tech Mechanical" },
-    { slug: "btech-cs-nit", name: "B.Tech Computer Science (NIT)" },
-  ]
+async function CourseGrid() {
+  const courses = await prisma.course.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="courses" className="space-y-3">
       <h2 id="courses" className="font-serif text-xl font-semibold">
         Courses
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((c) => (
-          <Link key={c.slug} href={`/course/${c.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{c.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Browse subjects and materials</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+        {courses.length ? (
+          courses.map((c) => (
+            <Link key={c.id} href={`/course/${c.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{c.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Browse subjects and materials</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))
+        ) : (
+          <p className="col-span-full text-sm text-muted-foreground">No courses found.</p>
+        )}
       </div>
     </section>
   )
 }
 
-function SubjectGrid() {
-  const demo = [
-    { slug: "dsa", name: "Data Structures & Algorithms" },
-    { slug: "dbms", name: "DBMS" },
-    { slug: "thermodynamics", name: "Thermodynamics" },
-  ]
+async function SubjectGrid() {
+  const subjects = await prisma.subject.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="subjects" className="space-y-3">
       <h2 id="subjects" className="font-serif text-xl font-semibold">
         Subjects
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {demo.map((s) => (
-          <Link key={s.slug} href={`/subject/${s.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{s.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Notes, PYQs, and videos</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+        {subjects.length ? (
+          subjects.map((s) => (
+            <Link key={s.id} href={`/subject/${s.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{s.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Notes, PYQs, and videos</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))
+        ) : (
+          <p className="col-span-full text-sm text-muted-foreground">No subjects found.</p>
+        )}
       </div>
     </section>
   )

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -1,16 +1,28 @@
 import Link from "next/link"
+import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
+import { prisma } from "@/lib/prisma"
 
-export default function CollegePage({ params }: { params: { slug: string } }) {
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
+export default async function CollegePage({ params }: { params: { slug: string } }) {
   const { slug } = params
-  const name = slugToTitle(slug)
+  const college = await prisma.college.findUnique({
+    where: { slug },
+    include: { courses: { orderBy: { name: "asc" } } },
+  })
+  if (!college) return notFound()
 
   return (
     <div className="space-y-6">
-      <PageTracker title={name} href={`/college/${slug}`} type="nav" />
+      <PageTracker title={college.name} href={`/college/${college.slug}`} type="nav" />
       <header className="space-y-1">
-        <h1 className="font-serif text-2xl font-semibold">{name}</h1>
-        <p className="text-sm text-muted-foreground">Browse courses and subjects from {name}.</p>
+        <h1 className="font-serif text-2xl font-semibold">{college.name}</h1>
+        <p className="text-sm text-muted-foreground">
+          Browse courses and subjects from {college.name}.
+        </p>
       </header>
 
       <section aria-labelledby="courses" className="space-y-2">
@@ -18,22 +30,22 @@ export default function CollegePage({ params }: { params: { slug: string } }) {
           Courses
         </h2>
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {["btech-cse", "bsc-physics", "mba-core"].map((c) => (
-            <li key={c}>
-              <Link
-                href={`/course/${c}`}
-                className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
-              >
-                {slugToTitle(c)}
-              </Link>
-            </li>
-          ))}
+          {college.courses.length ? (
+            college.courses.map((c) => (
+              <li key={c.id}>
+                <Link
+                  href={`/course/${c.slug}`}
+                  className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
+                >
+                  {c.name}
+                </Link>
+              </li>
+            ))
+          ) : (
+            <li className="col-span-full text-sm text-muted-foreground">No courses found.</li>
+          )}
         </ul>
       </section>
     </div>
   )
-}
-
-function slugToTitle(s: string) {
-  return s.replace(/-/g, " ").replace(/\b\w/g, (m) => m.toUpperCase())
 }

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -1,15 +1,25 @@
 import Link from "next/link"
+import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
+import { prisma } from "@/lib/prisma"
 
-export default function CoursePage({ params }: { params: { slug: string } }) {
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
+export default async function CoursePage({ params }: { params: { slug: string } }) {
   const { slug } = params
-  const name = slugToTitle(slug)
+  const course = await prisma.course.findFirst({
+    where: { slug },
+    include: { subjects: { orderBy: { name: "asc" } }, college: true },
+  })
+  if (!course) return notFound()
 
   return (
     <div className="space-y-6">
-      <PageTracker title={name} href={`/course/${slug}`} type="nav" />
+      <PageTracker title={course.name} href={`/course/${course.slug}`} type="nav" />
       <header className="space-y-1">
-        <h1 className="font-serif text-2xl font-semibold">{name}</h1>
+        <h1 className="font-serif text-2xl font-semibold">{course.name}</h1>
         <p className="text-sm text-muted-foreground">Select a subject to see materials, PYQs, and videos.</p>
       </header>
 
@@ -18,22 +28,22 @@ export default function CoursePage({ params }: { params: { slug: string } }) {
           Subjects
         </h2>
         <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {["discrete-math", "data-structures", "operating-systems"].map((s) => (
-            <li key={s}>
-              <Link
-                href={`/subject/${s}`}
-                className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
-              >
-                {slugToTitle(s)}
-              </Link>
-            </li>
-          ))}
+          {course.subjects.length ? (
+            course.subjects.map((s) => (
+              <li key={s.id}>
+                <Link
+                  href={`/subject/${s.slug}`}
+                  className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
+                >
+                  {s.name}
+                </Link>
+              </li>
+            ))
+          ) : (
+            <li className="col-span-full text-sm text-muted-foreground">No subjects found.</li>
+          )}
         </ul>
       </section>
     </div>
   )
-}
-
-function slugToTitle(s: string) {
-  return s.replace(/-/g, " ").replace(/\b\w/g, (m) => m.toUpperCase())
 }


### PR DESCRIPTION
## Summary
- Force node runtime and disable caching on browse, college, course, and subject pages so admin edits show immediately
- Show empty-state messages when no colleges, courses, or subjects exist

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5120e35e08330b3a34244d9e7f120