### PR TITLE
Fix browse views and add empty-state messages

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { prisma } from "@/lib/prisma"
 
+export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 type SearchParams = { by?: "college" | "course" | "subject" }
@@ -55,20 +56,24 @@ async function CollegeGrid() {
       <h2 id="colleges" className="font-serif text-xl font-semibold">
         Colleges
       </h2>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {colleges.map((c) => (
-          <Link key={c.id} href={`/college/${c.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{c.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Explore courses and subjects</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
+      {colleges.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {colleges.map((c) => (
+            <Link key={c.id} href={`/college/${c.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{c.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Explore courses and subjects</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No colleges found.</p>
+      )}
     </section>
   )
 }
@@ -80,20 +85,24 @@ async function CourseGrid() {
       <h2 id="courses" className="font-serif text-xl font-semibold">
         Courses
       </h2>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {courses.map((c) => (
-          <Link key={c.id} href={`/course/${c.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{c.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Browse subjects and materials</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
+      {courses.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {courses.map((c) => (
+            <Link key={c.id} href={`/course/${c.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{c.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Browse subjects and materials</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No courses found.</p>
+      )}
     </section>
   )
 }
@@ -105,20 +114,24 @@ async function SubjectGrid() {
       <h2 id="subjects" className="font-serif text-xl font-semibold">
         Subjects
       </h2>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {subjects.map((s) => (
-          <Link key={s.id} href={`/subject/${s.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-foreground/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base">{s.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Notes, PYQs, and videos</p>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
+      {subjects.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {subjects.map((s) => (
+            <Link key={s.id} href={`/subject/${s.slug}`} className="group">
+              <Card className="transition-colors group-hover:border-foreground/20">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{s.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground">Notes, PYQs, and videos</p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No subjects found.</p>
+      )}
     </section>
   )
 }

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
+export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function CollegePage({ params }: { params: { slug: string } }) {
@@ -27,18 +28,22 @@ export default async function CollegePage({ params }: { params: { slug: string }
         <h2 id="courses" className="font-serif text-xl font-semibold">
           Courses
         </h2>
-        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {college.courses.map((c) => (
-            <li key={c.id}>
-              <Link
-                href={`/course/${c.slug}`}
-                className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
-              >
-                {c.name}
-              </Link>
-            </li>
-          ))}
-        </ul>
+        {college.courses.length > 0 ? (
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {college.courses.map((c) => (
+              <li key={c.id}>
+                <Link
+                  href={`/course/${c.slug}`}
+                  className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
+                >
+                  {c.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No courses found.</p>
+        )}
       </section>
     </div>
   )

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
+export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function CoursePage({ params }: { params: { slug: string } }) {
@@ -25,18 +26,22 @@ export default async function CoursePage({ params }: { params: { slug: string } 
         <h2 id="subjects" className="font-serif text-xl font-semibold">
           Subjects
         </h2>
-        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {course.subjects.map((s) => (
-            <li key={s.id}>
-              <Link
-                href={`/subject/${s.slug}`}
-                className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
-              >
-                {s.name}
-              </Link>
-            </li>
-          ))}
-        </ul>
+        {course.subjects.length > 0 ? (
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {course.subjects.map((s) => (
+              <li key={s.id}>
+                <Link
+                  href={`/subject/${s.slug}`}
+                  className="block rounded-lg border border-border bg-card px-3 py-2 hover:bg-muted"
+                >
+                  {s.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No subjects found.</p>
+        )}
       </section>
     </div>
   )

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
+export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function SubjectPage({ params }: { params: { slug: string } }) {
@@ -29,99 +30,81 @@ export default async function SubjectPage({ params }: { params: { slug: string }
         <h2 id="materials" className="font-serif text-xl font-semibold">
           Materials
         </h2>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {notes.length > 0
-            ? notes.map((n) => (
-                <Link
-                  key={n.id}
-                  href={`/view/note?title=${encodeURIComponent(n.title)}&url=${encodeURIComponent(
-                    n.fileUrl || n.externalUrl || "",
-                  )}`}
-                  className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
-                >
-                  <div className="flex items-center gap-2">
-                    <FileText className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">{n.title}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">{n.type} • Opens inside site</p>
-                </Link>
-              ))
-            : [1, 2, 3].map((i) => (
-                <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
-                  <div className="flex items-center gap-2">
-                    <FileText className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">Material {i}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
-                </article>
-              ))}
-        </div>
+        {notes.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {notes.map((n) => (
+              <Link
+                key={n.id}
+                href={`/view/note?title=${encodeURIComponent(n.title)}&url=${encodeURIComponent(
+                  n.fileUrl || n.externalUrl || "",
+                )}`}
+                className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
+              >
+                <div className="flex items-center gap-2">
+                  <FileText className="h-4 w-4" aria-hidden="true" />
+                  <span className="text-sm font-medium">{n.title}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{n.type} • Opens inside site</p>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No materials found.</p>
+        )}
       </section>
 
       <section aria-labelledby="pyqs" className="space-y-3">
         <h2 id="pyqs" className="font-serif text-xl font-semibold">
           PYQs
         </h2>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {pyqs.length > 0
-            ? pyqs.map((q) => (
-                <a
-                  key={q.id}
-                  href={q.fileUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
-                >
-                  <div className="flex items-center gap-2">
-                    <HelpCircle className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">{q.examType} {q.year}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">PDF • Opens in new tab</p>
-                </a>
-              ))
-            : [1, 2, 3].map((i) => (
-                <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
-                  <div className="flex items-center gap-2">
-                    <HelpCircle className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">PYQ {i}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
-                </article>
-              ))}
-        </div>
+        {pyqs.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {pyqs.map((q) => (
+              <a
+                key={q.id}
+                href={q.fileUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
+              >
+                <div className="flex items-center gap-2">
+                  <HelpCircle className="h-4 w-4" aria-hidden="true" />
+                  <span className="text-sm font-medium">{q.examType} {q.year}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">PDF • Opens in new tab</p>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No PYQs found.</p>
+        )}
       </section>
 
       <section aria-labelledby="videos" className="space-y-3">
         <h2 id="videos" className="font-serif text-xl font-semibold">
           Videos
         </h2>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {videos.length > 0
-            ? videos.map((v) => (
-                <Link
-                  key={v.id}
-                  href={`/view/video?v=${encodeURIComponent(
-                    `https://www.youtube.com/watch?v=${v.youtubeId}`,
-                  )}&title=${encodeURIComponent(v.title)}`}
-                  className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
-                >
-                  <div className="flex items-center gap-2">
-                    <PlayCircle className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">{v.title}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">YouTube • Opens inside site</p>
-                </Link>
-              ))
-            : [1, 2, 3].map((i) => (
-                <article key={i} className="rounded-xl border border-border bg-card p-4 opacity-60">
-                  <div className="flex items-center gap-2">
-                    <PlayCircle className="h-4 w-4" aria-hidden="true" />
-                    <span className="text-sm font-medium">Video {i}</span>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">Placeholder</p>
-                </article>
-              ))}
-        </div>
+        {videos.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {videos.map((v) => (
+              <Link
+                key={v.id}
+                href={`/view/video?v=${encodeURIComponent(
+                  `https://www.youtube.com/watch?v=${v.youtubeId}`,
+                )}&title=${encodeURIComponent(v.title)}`}
+                className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/30"
+              >
+                <div className="flex items-center gap-2">
+                  <PlayCircle className="h-4 w-4" aria-hidden="true" />
+                  <span className="text-sm font-medium">{v.title}</span>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">YouTube • Opens inside site</p>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No videos found.</p>
+        )}
       </section>
     </div>
   )


### PR DESCRIPTION
## Summary
- Force Node runtime and dynamic rendering on browse, college, course, and subject pages for up-to-date data
- Add empty-state messages for colleges, courses, subjects, and subject resources

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b51800d7588330923e7cd388d264dc