### PR TITLE
Ensure browse pages fetch fresh data

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { unstable_noStore as noStore } from "next/cache"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { prisma } from "@/lib/prisma"
@@ -15,6 +16,7 @@ const tabs = [
 ] as const
 
 export default function BrowsePage({ searchParams }: { searchParams: SearchParams }) {
+  noStore()
   const active = (searchParams.by || "college") as SearchParams["by"]
 
   return (
@@ -50,6 +52,7 @@ export default function BrowsePage({ searchParams }: { searchParams: SearchParam
 }
 
 async function CollegeGrid() {
+  noStore()
   const colleges = await prisma.college.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="colleges" className="space-y-3">
@@ -79,6 +82,7 @@ async function CollegeGrid() {
 }
 
 async function CourseGrid() {
+  noStore()
   const courses = await prisma.course.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="courses" className="space-y-3">
@@ -108,6 +112,7 @@ async function CourseGrid() {
 }
 
 async function SubjectGrid() {
+  noStore()
   const subjects = await prisma.subject.findMany({ orderBy: { name: "asc" } })
   return (
     <section aria-labelledby="subjects" className="space-y-3">

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
@@ -7,6 +8,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function CollegePage({ params }: { params: { slug: string } }) {
+  noStore()
   const { slug } = params
   const college = await prisma.college.findUnique({
     where: { slug },

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
@@ -7,6 +8,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function CoursePage({ params }: { params: { slug: string } }) {
+  noStore()
   const { slug } = params
   const course = await prisma.course.findFirst({
     where: { slug },

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { FileText, HelpCircle, PlayCircle } from "lucide-react"
 import Link from "next/link" // use internal viewers
 import { notFound } from "next/navigation"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
@@ -8,6 +9,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export default async function SubjectPage({ params }: { params: { slug: string } }) {
+  noStore()
   const subject = await prisma.subject.findFirst({
     where: { slug: params.slug },
     include: { materials: true, pyqs: true, videos: true },


### PR DESCRIPTION
## Summary
- disable caching for browse index grids to reflect admin edits immediately
- ensure college, course, and subject detail pages bypass Next.js cache for live updates

## Testing
- `pnpm lint` *(fails: interactive setup prompt)*
- `pnpm build` *(fails: missing Prisma client module)*

------
https://chatgpt.com/codex/tasks/task_e_68b51ee54ac483308dcba72e82eaffc0