### PR TITLE
Ensure browse pages stay fresh

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 type SearchParams = { by?: "college" | "course" | "subject" }
 

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 export default async function CollegePage({ params }: { params: { slug: string } }) {
   noStore()

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 export default async function CoursePage({ params }: { params: { slug: string } }) {
   noStore()

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 export default async function SubjectPage({ params }: { params: { slug: string } }) {
   noStore()


### PR DESCRIPTION
## Summary
- disable caching on browse, college, course, and subject pages to always load current data

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_68b5212ca5e08330b7f7c3cacc2b42bb