### PR TITLE
Fix browse pages to use stable noStore for live updates

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { unstable_noStore as noStore } from "next/cache"
+import { noStore } from "next/cache"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { prisma } from "@/lib/prisma"
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 export const revalidate = 0
+export const fetchCache = "force-no-store"
 
 type SearchParams = { by?: "college" | "course" | "subject" }
 

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { unstable_noStore as noStore } from "next/cache"
+import { noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 export const revalidate = 0
+export const fetchCache = "force-no-store"
 
 export default async function CollegePage({ params }: { params: { slug: string } }) {
   noStore()

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { unstable_noStore as noStore } from "next/cache"
+import { noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 export const revalidate = 0
+export const fetchCache = "force-no-store"
 
 export default async function CoursePage({ params }: { params: { slug: string } }) {
   noStore()

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -1,13 +1,14 @@
 import { FileText, HelpCircle, PlayCircle } from "lucide-react"
 import Link from "next/link" // use internal viewers
 import { notFound } from "next/navigation"
-import { unstable_noStore as noStore } from "next/cache"
+import { noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 export const revalidate = 0
+export const fetchCache = "force-no-store"
 
 export default async function SubjectPage({ params }: { params: { slug: string } }) {
   noStore()


### PR DESCRIPTION
## Summary
- use stable `noStore` in browse-related pages
- force no-store fetch cache so college, course, and subject listings stay fresh

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b5252d871c833098990854068a4bb9