### PR TITLE
Fix noStore import for Next.js 15

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { noStore } from "next/cache"
+import { unstable_noStore as noStore } from "next/cache"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { prisma } from "@/lib/prisma"

--- a/app/college/[slug]/page.tsx
+++ b/app/college/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { noStore } from "next/cache"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 

--- a/app/course/[slug]/page.tsx
+++ b/app/course/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { noStore } from "next/cache"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 

--- a/app/subject/[slug]/page.tsx
+++ b/app/subject/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { FileText, HelpCircle, PlayCircle } from "lucide-react"
 import Link from "next/link" // use internal viewers
 import { notFound } from "next/navigation"
-import { noStore } from "next/cache"
+import { unstable_noStore as noStore } from "next/cache"
 import { PageTracker } from "@/components/tracking/page-tracker"
 import { prisma } from "@/lib/prisma"
 


### PR DESCRIPTION
## Summary
- use `unstable_noStore` from `next/cache` across browse and detail pages

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b5285d1c18833084ec6b7c7c8ebb6b